### PR TITLE
Fix: Use correct class path for UnusedFileReportBuildTask

### DIFF
--- a/src/Jobs/UnusedFileReportJob.php
+++ b/src/Jobs/UnusedFileReportJob.php
@@ -2,9 +2,9 @@
 
 namespace RobIngram\SilverStripe\UnusedFileReport\Jobs;
 
+use RobIngram\SilverStripe\UnusedFileReport\Tasks\UnusedFileReportBuildTask;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
-use RobIngram\SilverStripe\UnusedFileReport\UnusedFileReportBuildTask;
 use SilverStripe\Control\HTTPRequest;
 
 /**


### PR DESCRIPTION
This fixes the path to the UnusedFileReportBuildTask::class which caused breakage. This was previously overlooked until I ran it directly from within the symbiote/silverstripe-queuedjobs admin.